### PR TITLE
Remove user groups if no groups are passed

### DIFF
--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -93,16 +93,18 @@ class SAMLGroupsIdentityProvider(IdentityProvider):
             if isinstance(grp_names, str):
                 # If only one group is returned, it is returned as a string by saml auth provider
                 grp_names = [grp_names]
+        else:
+            grp_names = []
 
-            user_groups = self._group_provider.get_user_groups(identifier=identifier)
-            for group in user_groups:
-                if group.name not in grp_names:
-                    self._group_provider.remove_group_member(
-                        group_name=group.name, identifier=identifier
-                    )
+        user_groups = self._group_provider.get_user_groups(identifier=identifier)
+        for group in user_groups:
+            if group.name not in grp_names:
+                self._group_provider.remove_group_member(
+                    group_name=group.name, identifier=identifier
+                )
 
-            for grp_name in grp_names:
-                self._group_provider.add_group_member(group_name=grp_name, identifier=identifier)
+        for grp_name in grp_names:
+            self._group_provider.add_group_member(group_name=grp_name, identifier=identifier)
 
         return identity_info
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@
 
 """Common fixtures for integration tests."""
 from secrets import token_hex
+from unittest.mock import Mock
 
 import onelogin
 import pytest
@@ -76,6 +77,7 @@ def config_fixture():
         "MULTIPASS_AUTH_PROVIDERS": multipass_auth_providers,
         "MULTIPASS_IDENTITY_PROVIDERS": multipass_identity_providers,
         "MULTIPASS_PROVIDER_MAP": multipass_provider_map,
+        "MULTIPASS_REQUIRE_IDENTITY": True,
     }
 
 
@@ -98,7 +100,7 @@ def multipass_fixture(app, monkeypatch):
     multipass = Multipass()
     multipass.register_provider(SAMLGroupsIdentityProvider, "saml_groups")
     multipass.init_app(app)
-    multipass.identity_handler(lambda identity: None)
+    multipass.identity_handler(Mock(return_value=None))
     monkeypatch.setattr(
         onelogin.saml2.response.OneLogin_Saml2_Response, "is_valid", lambda *args, **kwargs: True
     )  # disable signature validation of SAML response


### PR DESCRIPTION
If a user no longer belongs to any group, all previous group memberships must be removed. This case has not yet been dealt with.