### PR TITLE
Include migrations in package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,9 @@ python_requires = ~=3.8
 install_requires =
     flask-multipass[saml]>=0.4.3
 
+[options.package_data]
+flask_multipass_saml_groups = migrations/*.py
+
 [options.packages.find]
 include =
     flask_multipass_saml_groups


### PR DESCRIPTION
Database migration files must be included in the installation.