### PR TITLE
Use operator workflows

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,14 +5,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
-    name: Integration Tests
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install required native libraries
-        run: sudo bash -xe install-libs.sh
-      - name: Install tox
-        run: python3 -m pip install tox
-      - name: Run integration tests
-        run: |
-          tox -e integration
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      pre-run-script: .github/test-pre-script.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask-multipass[saml]>=0.4.*
+flask-multipass[saml]>=0.4.8
 indico>=3.2
 flask_sqlalchemy

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ packages = find:
 include_package_data = true
 python_requires = ~=3.8
 install_requires =
-    flask-multipass[saml]>=0.4.3
+    flask-multipass[saml]>=0.4.8
 
 [options.package_data]
 flask_multipass_saml_groups = migrations/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    # pytest-operator has some required options for pytest in order to be usable with operator workflows
+    # operator workflows require some options to pytest, which pytest-operator includes
     pytest-operator
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements.dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -99,6 +99,8 @@ commands =
 description = Run integration tests
 deps =
     pytest
+    # pytest-operator has some required options for pytest in order to be usable with operator workflows
+    pytest-operator
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements.dev.txt
 commands =


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use operator workflows for the integration test.

### Rationale

According to https://github.com/canonical/is-charms-contributing-guide/blob/main/CONTRIBUTING.md#ci-cd, all repos owned by IS Charms should use operator workflows.

### Module Changes


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

