### PR TITLE
Switch to using edge runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,3 +9,5 @@ jobs:
     secrets: inherit
     with:
       pre-run-script: .github/test-pre-script.sh
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Switch to using edge self-hosted runners

### Rationale

So that we use the edge runners in our team before they are rolled out more broadly

### Module Changes

n/a

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->