### PR TITLE
Remove experimental status warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This package provides an identity provider for [Flask-Multipass](https://github.
 which allows you to use SAML groups. It is designed to be used
 as a plugin for [Indico](https://github.com/indico/indico).
 
-> **Warning**
-> The current code base has not been extensively tested and should be considered experimental.
-
 
 ## Motivation
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Remove the experimental status warning in the README.

### Rationale

The plugin has been running in our production environment for over a month, and even longer in our staging environment, so it should be considered "extensively tested".

### Module Changes

n/a

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->