### PR TITLE
Use self-hosted runners for integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,3 +11,4 @@ jobs:
       pre-run-script: .github/test-pre-script.sh
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
+      provider: lxd

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,3 +9,5 @@ jobs:
     secrets: inherit
     with:
       pre-run-script: .github/test-pre-script.sh
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"

--- a/tox.ini
+++ b/tox.ini
@@ -101,6 +101,9 @@ deps =
     pytest
     # operator workflows require some options to pytest, which pytest-operator includes
     pytest-operator
+    # Type error problem with newer version of macaroonbakery,
+    # required for use with operator workflows
+    macaroonbakery==1.3.2
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements.dev.txt
 commands =


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use `edge` self-hosted runner for integration tests.

### Rationale

- Reduce load on GitHub-provided runner on the organisation.
- Test out the edge revision of github-runner charm on this repo.

### Module Changes

<!-- Any high level changes to modules and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->