### PR TITLE
ISD-1158: After clearing the session, set ['_multipass_next_url'] to control redirection after login

### DIFF
--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -6,7 +6,7 @@ import operator
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterable, Optional, Type
 
-from flask import current_app, redirect, session, url_for
+from flask import current_app, redirect, request, session, url_for
 from flask_multipass import (
     AuthInfo,
     Group,
@@ -187,6 +187,7 @@ class SAMLGroupsIdentityProvider(IdentityProvider):
         expires = session.get(EXPIRY_SESSION_KEY)
         if expires and expires < datetime.now(timezone.utc):
             session.clear()
+            session["_multipass_next_url"] = request.url
 
             return redirect(url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"]))
         return None

--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -5,6 +5,7 @@
 import operator
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterable, Optional, Type
+from urllib.parse import urlsplit
 
 from flask import current_app, redirect, request, session, url_for
 from flask_multipass import (
@@ -19,7 +20,6 @@ from werkzeug import Response
 
 from flask_multipass_saml_groups.group_provider.base import GroupProvider
 from flask_multipass_saml_groups.group_provider.sql import SQLGroupProvider
-from urllib.parse import urlsplit
 
 DEFAULT_IDENTIFIER_FIELD = "_saml_nameid_qualified"
 SAML_GRP_ATTR_NAME = "urn:oasis:names:tc:SAML:2.0:profiles:attribute:DCE:groups"

--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -5,7 +5,6 @@
 import operator
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterable, Optional, Type
-from urllib.parse import urlsplit
 
 from flask import current_app, redirect, request, session, url_for
 from flask_multipass import (

--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -188,11 +188,8 @@ class SAMLGroupsIdentityProvider(IdentityProvider):
         expires = session.get(EXPIRY_SESSION_KEY)
         if expires and expires < datetime.now(timezone.utc):
             session.clear()
-            redirect_url = url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"])
-            next_url = request.url
-            url_info = urlsplit(next_url)
-            url_is_valid = not url_info.netloc or url_info.netloc == request.host
-            if next_url and url_is_valid:
-                redirect_url += f"?next={next_url}"
-            return redirect(redirect_url)
+
+            return redirect(
+                f"{url_for(current_app.config['MULTIPASS_LOGIN_ENDPOINT'])}?next={request.url}"
+            )
         return None

--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -188,12 +188,11 @@ class SAMLGroupsIdentityProvider(IdentityProvider):
         expires = session.get(EXPIRY_SESSION_KEY)
         if expires and expires < datetime.now(timezone.utc):
             session.clear()
-
+            redirect_url = url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"])
             next_url = request.url
             url_info = urlsplit(next_url)
             url_is_valid = not url_info.netloc or url_info.netloc == request.host
             if next_url and url_is_valid:
-                session["_multipass_next_url"] = next_url
-
-            return redirect(url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"]))
+                redirect_url += f"?next={next_url}"
+            return redirect(redirect_url)
         return None

--- a/flask_multipass_saml_groups/provider.py
+++ b/flask_multipass_saml_groups/provider.py
@@ -189,6 +189,6 @@ class SAMLGroupsIdentityProvider(IdentityProvider):
             session.clear()
 
             return redirect(
-                f"{url_for(current_app.config['MULTIPASS_LOGIN_ENDPOINT'])}?next={request.url}"
+                url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"], next=request.url)
             )
         return None

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -30,9 +30,10 @@ def test_redirect_after_invalid_session(app, user):
 
         frozen_datetime.tick(delta=timedelta(seconds=DEFAULT_SESSION_EXPIRY + 1))
         with client:
-            resp = client.get("/")
+            next_url = "/sample"
+            resp = client.get(next_url)
 
-            _assert_session_invalidation(resp)
+            _assert_session_invalidation(resp, next_url)
 
 
 @pytest.mark.usefixtures("multipass")
@@ -76,14 +77,16 @@ def test_no_session_invalidation_for_users_without_groups(app, user):
             _assert_no_session_invalidation(resp)
 
 
-def _assert_session_invalidation(response: Response):
-    """Assert that the session is invalidated and the user is redirected to the login page.
+def _assert_session_invalidation(response: Response, next_url: str):
+    """Assert that the session is invalidated and the user is redirected to the login url
+    specifying the next URL after successful login.
 
     Args:
         response: The response to check.
     """
     assert response.status_code == 302
-    assert response.location == url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"])
+    assert url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"]) in response.location
+    assert next_url in response.location
     assert not session
 
 

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -83,6 +83,7 @@ def _assert_session_invalidation(response: Response, next_url: str):
 
     Args:
         response: The response to check.
+        next_url: URL to redirect to after login
     """
     assert response.status_code == 302
     assert url_for(current_app.config["MULTIPASS_LOGIN_ENDPOINT"]) in response.location

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -485,9 +485,11 @@ def test_redirect_to_login_if_session_expired(app, client):
     with client.session_transaction() as sess:
         sess[EXPIRY_SESSION_KEY] = dt_now - timedelta(seconds=1)
 
-    resp = client.get("/sample")
+    next_url = "/sample"
+    resp = client.get(next_url)
     assert resp.status_code == 302
-    assert resp.location == url_for(app.config["MULTIPASS_LOGIN_ENDPOINT"])
+    assert url_for(app.config["MULTIPASS_LOGIN_ENDPOINT"]) in resp.location
+    assert next_url in resp.location
 
 
 @freeze_time("Jan 14th, 2024")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -457,7 +457,7 @@ def test_search_groups_non_exact_returns_all_matched_groups(auth_info, provider,
 
 @freeze_time("Jan 14th, 2024")
 @pytest.mark.usefixtures("provider")
-def test_session_only_has_redirect_key_if_expired(app):
+def test_session_is_cleared_if_expired(app):
     """
     arrange: a session with an expiry date in the past
     act: the flask before_request signal is triggered
@@ -470,7 +470,7 @@ def test_session_only_has_redirect_key_if_expired(app):
 
         app.preprocess_request()
 
-        assert list(session.keys()) == ["_multipass_next_url"]
+        assert session == {}
 
 
 @freeze_time("Jan 14th, 2024")

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -457,7 +457,7 @@ def test_search_groups_non_exact_returns_all_matched_groups(auth_info, provider,
 
 @freeze_time("Jan 14th, 2024")
 @pytest.mark.usefixtures("provider")
-def test_session_is_cleared_if_expired(app):
+def test_session_only_has_redirect_key_if_expired(app):
     """
     arrange: a session with an expiry date in the past
     act: the flask before_request signal is triggered
@@ -470,7 +470,7 @@ def test_session_is_cleared_if_expired(app):
 
         app.preprocess_request()
 
-        assert session == {}
+        assert list(session.keys()) == ["_multipass_next_url"]
 
 
 @freeze_time("Jan 14th, 2024")


### PR DESCRIPTION
Tested with `login.ubuntu.com` and `login.staging.ubuntu.com` and locally deployed indico.

The SAML groups plugin triggers a session refresh to update the groups a user belongs to. It has been noticed that a redirect after the refresh with the SAML IdP does not redirect to the page a user previously visited. like in https://github.com/indico/flask-multipass/blob/master/flask_multipass/core.py#L122C13-L126, this PR do some validation on the request's target url and sets the '_multipass_next_url' to that url for after the user logs back in.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->