### PR TITLE
remove exact version pin for plugin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3087,4 +3087,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.12"
-content-hash = "9452479b6717d48d48fc094f31f3b9d5365826941587ab84f33a771378c06e04"
+content-hash = "bca261a83845fb7005569f9043ec97bda0fc9b6fb459724ef081944fd910c118"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.10, <3.12"
 flask-multipass = {extras = ["saml"], version = "0.4.9"}
-# The package version here can force and upgrade of indico when the plugin is used
+# The package version here can force an upgrade of indico when the plugin is used
 # thus we must only specify compatibility rather than pinning the exact version
-indico = ">=3.2.8, 4.0.0"
+indico = ">=3.2.8, 4"
 flask_sqlalchemy = "3.0.3"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ disable = "wrong-import-order"
 
 [tool.poetry]
 name = "flask-multipass-saml-groups"
-version = "0.2.0"
+version = "0.3.0"
 description = "This package provides an identity provider for Flask-Multipass, which allows you to use SAML groups. It is designed to be used as a plugin for Indico."
 authors = ["canonical-is-devops <is-devops-team@canonical.com>"]
 license = "Apache-2.0 license"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ python = ">=3.10, <3.12"
 flask-multipass = {extras = ["saml"], version = "0.4.9"}
 # The package version here can force an upgrade of indico when the plugin is used
 # thus we must only specify compatibility rather than pinning the exact version
-indico = ">=3.2.8, 4"
+indico = ">=3.2.8, <4"
 flask_sqlalchemy = "3.0.3"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,9 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.10, <3.12"
 flask-multipass = {extras = ["saml"], version = "0.4.9"}
-indico = "3.2.9"
+# The package version here can force and upgrade of indico when the plugin is used
+# thus we must only specify compatibility rather than pinning the exact version
+indico = ">=3.2.8, 4.0.0"
 flask_sqlalchemy = "3.0.3"
 
 [build-system]


### PR DESCRIPTION
pinning the exact indico version can influence the version of indico itself when this plugin is used without operator knowledge. So we are removing the exact version pin for indico and specify compatible versions instead.

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Module Changes

<!-- Any high level changes to modules and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->