### PR TITLE
Use edge runners

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,5 +10,5 @@ jobs:
     with:
       pre-run-script: .github/test-pre-script.sh
       self-hosted-runner: true
-      self-hosted-runner-label: "jammy"
+      self-hosted-runner-label: "edge"
       provider: lxd

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
     with:
       pre-run-script: .github/test-pre-script.sh
       self-hosted-runner: true
-      self-hosted-runner-label: "jammy"
+      self-hosted-runner-label: "edge"


### PR DESCRIPTION
### Overview

Specify edge label for self-hosted runners

### Rationale

"jammy" is already added by operator workflows : https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test_run.yaml#L173 

and not specifying the flavour will give you a random runner.


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->