### PR TITLE
Pin xmlsec to 1.3.13

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2602,10 +2602,9 @@ files = [
 
 [package.dependencies]
 defusedxml = "0.6.0"
-isodate = "0.6.1"
-# Indico pins lxml
-lxml = ">=5.2.1"
-xmlsec = "1.3.13"
+isodate = ">=0.5.0"
+lxml = ">=3.3.5"
+xmlsec = ">=1.0.5"
 
 [package.extras]
 test = ["coverage (>=4.5.2)", "coveralls (==1.5.1)", "flake8 (==3.6.0)", "freezegun (==0.3.11)", "pylint (==1.9.4)"]
@@ -3673,4 +3672,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~=3.12.2"
-content-hash = "34ca1cd0a0d0540dd4a810f82f8a5bb3c19feb37cf6bc44015e319c0bb982ea1"
+content-hash = "c20f96aa563d099919ce2097cad916660815a0d7f68a35177a56ce7ff4368aa2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ flask-multipass = {extras = ["saml"], version = "0.5.4"}
 # thus we must only specify compatibility rather than pinning the exact version
 indico = ">=3.3.1, <4"
 flask_sqlalchemy = "3.0.5"
+xmlsec = "1.3.13"
 
 [tool.poetry.plugins."indico.plugins"]
 saml_groups = "flask_multipass_saml_groups.plugin:SAMLGroupsPlugin"


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Pin xmlsec to 1.3.13

### Rationale

<!-- The reason the change is needed -->
xmlsec > 1.3.13 requires a different set pf apt packages to work

### Module Changes

<!-- Any high level changes to modules and why -->
N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->