### PR TITLE
Use new team name in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/is-charms
+*       @canonical/platform-engineering


### PR DESCRIPTION
Replace references to is-charms to platform-engineering in CODEOWNERS